### PR TITLE
Correct opacity specification

### DIFF
--- a/alacritty-default-colour-scheme
+++ b/alacritty-default-colour-scheme
@@ -64,6 +64,12 @@ window:
   #     - buttonless: Title bar, transparent background and no title bar buttons
   decorations: none
 
+  # Background opacity
+  #
+  # Window opacity as a floating point number from `0.0` to `1.0`.
+  # The value `0.0` is completely transparent and `1.0` is opaque.
+  background_opacity: 0.85
+
   # Startup Mode (changes require restart)
   #
   # Values for `startup_mode`:
@@ -473,12 +479,6 @@ bell:
   #     args: ["Hello, World!"]
   #
   #command: None
-
-# Background opacity
-#
-# Window opacity as a floating point number from `0.0` to `1.0`.
-# The value `0.0` is completely transparent and `1.0` is opaque.
-background_opacity: 0.85
 
 selection:
   # This string contains all characters that are used as separators for


### PR DESCRIPTION
Move the opacity attribute from underneath the colour section to underneath the window version in order to comply with the changes in the newest alacritty versions.